### PR TITLE
Fix for https://github.com/jeff-hughes/shellcaster/issues/60

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -34,6 +34,7 @@ pub enum UserAction
 	DeleteAll,
 	Remove,
 	RemoveAll,
+	UnmarkDownloaded,
 
 	FilterPlayed,
 	FilterDownloaded,
@@ -185,6 +186,7 @@ impl Keybindings
 			(UserAction::DownloadAll, vec!["D".to_string()]),
 			(UserAction::Delete, vec!["x".to_string()]),
 			(UserAction::DeleteAll, vec!["X".to_string()]),
+			(UserAction::UnmarkDownloaded, vec!["u".to_string()]),
 			(UserAction::Remove, vec!["r".to_string()]),
 			(UserAction::RemoveAll, vec!["R".to_string()]),
 			(UserAction::FilterPlayed, vec!["1".to_string()]),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -73,6 +73,7 @@ pub enum UiMsg
 	Download(i64, i64),
 	DownloadMulti(Vec<(i64, i64)>),
 	DownloadAll(i64),
+	UnmarkDownloaded(i64, i64),
 	Delete(i64, i64),
 	DeleteAll(i64),
 	RemovePodcast(i64, bool),
@@ -435,6 +436,15 @@ impl<'a> Ui<'a>
 						}
 					}
 
+					Some(UserAction::UnmarkDownloaded) => {
+						if let ActivePanel::EpisodeMenu = self.active_panel {
+							if let Some(pod_id) = curr_pod_id {
+								if let Some(ep_id) = curr_ep_id {
+									return UiMsg::UnmarkDownloaded(pod_id, ep_id);
+								}
+							}
+						}
+					}
 					Some(UserAction::Remove) => match self.active_panel
 					{
 						ActivePanel::PodcastMenu => {

--- a/src/ui/popup.rs
+++ b/src/ui/popup.rs
@@ -226,6 +226,7 @@ impl<'a> PopupWin<'a>
 			(Some(UserAction::DownloadAll), "Download all:"),
 			(Some(UserAction::Delete), "Delete file:"),
 			(Some(UserAction::DeleteAll), "Delete all files:"),
+			(Some(UserAction::UnmarkDownloaded), "Unmark as downloaded:"),
 			(Some(UserAction::Remove), "Remove from list:"),
 			(Some(UserAction::RemoveAll), "Remove all from list:"),
 			// (None, ""),


### PR DESCRIPTION
added 'u' keybinding which unmarks an episode as downloaded (removes it from db), so it can be downloaded again