### PR TITLE
Command line flag to truncate long episode filenames to avoid Windows MAX_PATH failures

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,7 @@ pub struct Config
 	pub colors: AppColors,
 	pub filename_prefix: String,
 	pub filename_suffix: String,
+	pub short_filename: bool,
 }
 
 /// A temporary struct used to deserialize data from the TOML configuration
@@ -73,6 +74,7 @@ struct ConfigFromToml
 	colors: Option<AppColorsFromToml>,
 	filename_prefix: Option<String>,
 	filename_suffix: Option<String>,
+	short_filename: Option<bool>,
 }
 
 /// A temporary struct used to deserialize keybinding data from the TOML
@@ -202,6 +204,7 @@ impl Config
 					colors: Some(colors),
 					filename_prefix: None,
 					filename_suffix: None,
+					short_filename: None,
 				}
 			}
 		};
@@ -315,6 +318,7 @@ fn config_with_defaults(config_toml: ConfigFromToml) -> Result<Config>
 		colors: colors,
 		filename_prefix: filename_prefix,
 		filename_suffix: filename_suffix,
+		short_filename: config_toml.short_filename.unwrap_or(false),
 	});
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,14 @@ fn main() -> Result<()>
 				"Sets a custom config file location. Can also be set with environment variable."
 			)
 		)
+		.arg(Arg::new("short-filename")
+			.short('s')
+			.long("short-filename")
+			.global(true)
+			.help(
+				"Truncates filenames to 140 characters to stay under Windows path length limits."
+			)
+		)
 		.subcommand(Command::new("sync")
 			.about("Syncs all podcasts in database")
 			.arg(Arg::new("quiet")
@@ -132,7 +140,8 @@ fn main() -> Result<()>
 			);
 			process::exit(1);
 		});
-	let config = Config::new(&config_path)?;
+	let mut config = Config::new(&config_path)?;
+	config.short_filename = args.is_present("short-filename");
 
 	let mut db_path = config_path;
 	if !db_path.pop()

--- a/src/main_controller.rs
+++ b/src/main_controller.rs
@@ -667,6 +667,7 @@ impl MainController
 						self.config.max_retries,
 						&self.config.filename_prefix,
 						&self.config.filename_suffix,
+						self.config.short_filename,
 						&self.threadpool,
 						self.tx_to_main.clone(),
 					);


### PR DESCRIPTION
Added:

```
    -s, --short-filename    Truncates filenames to 140 characters to stay under Windows path length
                            limits.
```

I'm not sure that this was an issue when downloading on windows but I had this issue when downloading on linux and then attempting to move the file to windows and hitting the MAX PATH restriction.